### PR TITLE
@fix：

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -52,18 +52,18 @@ func NewScheduler() *TaskScheduler {
 //add spacing time job to list with number
 func (scheduler *TaskScheduler) AddFuncSpaceNumber(spaceTime int64, number int, f func()) {
 	task := getTaskWithFuncSpacingNumber(spaceTime, number, f)
-	scheduler.addTask(task)
+	scheduler.AddTask(task)
 }
 //add spacing time job to list with endTime
 func (scheduler *TaskScheduler) AddFuncSpace(spaceTime int64, endTime int64, f func()) {
 	task := getTaskWithFuncSpacing(spaceTime, endTime, f)
-	scheduler.addTask(task)
+	scheduler.AddTask(task)
 }
 
 //add func to list
 func (scheduler *TaskScheduler) AddFunc(unixTime int64, f func()) {
 	task := getTaskWithFunc(unixTime, f)
-	scheduler.addTask(task)
+	scheduler.AddTask(task)
 }
 
 func (scheduler *TaskScheduler) AddTaskInterface(task TaskInterface) {


### PR DESCRIPTION
修正time.go文件的`AddFuc*`相关的三个方法，应该处理runtime；2019-09-27 10:25:00

@body：
func (scheduler *TaskScheduler) AddFuncSpaceNumber(spaceTime int64, number int, f func()) {
	task := getTaskWithFuncSpacingNumber(spaceTime, number, f)
	scheduler.AddTask(task)
}
//add spacing time job to list with endTime
func (scheduler *TaskScheduler) AddFuncSpace(spaceTime int64, endTime int64, f func()) {
	task := getTaskWithFuncSpacing(spaceTime, endTime, f)
	scheduler.AddTask(task)
}

//add func to list
func (scheduler *TaskScheduler) AddFunc(unixTime int64, f func()) {
	task := getTaskWithFunc(unixTime, f)
	scheduler.AddTask(task)
}